### PR TITLE
fix: More scanner tests and parse !=<> correctly

### DIFF
--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -98,4 +98,18 @@ describe("Scanner", () => {
 		`);
 		expect(error).toHaveBeenCalledWith("[line 1] Error: Unterminated string.");
 	});
+
+	it("should report invalid characters", () => {
+		const error = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => undefined);
+		expect(scan("@")).toMatchInlineSnapshot(`
+			[
+			  "'': eof",
+			]
+		`);
+		expect(error).toHaveBeenCalledWith(
+			`[line 1] Error: Unexpected character "@"`,
+		);
+	});
 });

--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -9,7 +9,7 @@ function scan(source: string) {
 
 describe("Scanner", () => {
 	it("should scan an arithmetic expression", () => {
-		expect(scan("1 + 2 * 3 + 4")).toMatchInlineSnapshot(`
+		expect(scan("1 + 2 * 3 + 4 / 8")).toMatchInlineSnapshot(`
 			[
 			  "'1': number: 1",
 			  "'+': +",
@@ -18,6 +18,8 @@ describe("Scanner", () => {
 			  "'3': number: 3",
 			  "'+': +",
 			  "'4': number: 4",
+			  "'/': /",
+			  "'8': number: 8",
 			  "'': eof",
 			]
 		`);
@@ -111,5 +113,37 @@ describe("Scanner", () => {
 		expect(error).toHaveBeenCalledWith(
 			`[line 1] Error: Unexpected character "@"`,
 		);
+	});
+
+	it("should scan a string with an embedded newline", () => {
+		expect(
+			scan(`
+    "hello
+    world"`),
+		).toMatchInlineSnapshot(`
+			[
+			  "'"hello
+			    world"': string: hello
+			    world",
+			  "'': eof",
+			]
+		`);
+	});
+
+	it("should scan source with surprising terminal characters", () => {
+		expect(scan(`123.`)).toMatchInlineSnapshot(`
+			[
+			  "'123': number: 123",
+			  "'.': .",
+			  "'': eof",
+			]
+		`);
+		expect(scan(`12>`)).toMatchInlineSnapshot(`
+			[
+			  "'12': number: 12",
+			  "'>': >",
+			  "'': eof",
+			]
+		`);
 	});
 });

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -150,7 +150,7 @@ export class Scanner {
 				} else if (isAlpha(c)) {
 					this.#identifier();
 				} else {
-					error(this.line, `Unexpected character: ${c}`);
+					error(this.line, `Unexpected character "${c}"`);
 				}
 		}
 	}

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -118,7 +118,7 @@ export class Scanner {
 			case "=":
 			case "<":
 			case ">": // neat that `${c}=` works at the type level!
-				this.#addCharToken(this.#match("=") ? `${c}=` : "!");
+				this.#addCharToken(this.#match("=") ? `${c}=` : c);
 				break;
 
 			case "/":


### PR DESCRIPTION
## Overview

Fix a bug where `<` was scanned as `!`.