### PR TITLE
feat: Add AST, AST visitor, printer test

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
 		"lint:packages": "pnpm dedupe --check",
 		"lint:spelling": "cspell \"**\" \".github/**/*\"",
 		"prepare": "husky install",
-		"repl": "node --loader ts-node/esm --no-warnings src/index.ts",
+		"repl": "pnpm run:ts src/index.ts",
+		"run:ts": "node --loader ts-node/esm --no-warnings",
 		"should-semantic-release": "should-semantic-release --verbose",
 		"test": "vitest",
 		"tsc": "tsc"

--- a/src/ast.test.ts
+++ b/src/ast.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "vitest";
+
+import { Expr, ExpressionVisitor, visitExpr } from "./ast.js";
+
+const printer: ExpressionVisitor<string> = {
+	binary: (expr) => parenthesize(expr.operator.lexeme, expr.left, expr.right),
+	grouping: (expr) => parenthesize("group", expr.expr),
+	literal: (expr) => (expr.value === null ? "nil" : String(expr.value)),
+	unary: (expr) => parenthesize(expr.operator.lexeme, expr.right),
+};
+
+function parenthesize(name: string, ...exprs: Expr[]) {
+	const parts = ["(", name];
+	for (const expr of exprs) {
+		parts.push(" ");
+		parts.push(visitExpr(expr, printer));
+	}
+	parts.push(")");
+	return parts.join("");
+}
+
+test("AST Visitor", () => {
+	const expr: Expr = {
+		kind: "binary",
+		left: {
+			kind: "unary",
+			operator: { lexeme: "-", line: 1, literal: null, type: "-" },
+			right: { kind: "literal", value: 123 },
+		},
+		operator: { lexeme: "*", line: 1, literal: null, type: "*" },
+		right: {
+			expr: {
+				kind: "literal",
+				value: 45.67,
+			},
+			kind: "grouping",
+		},
+	};
+	const text = visitExpr(expr, printer);
+	expect(text).toEqual("(* (- 123) (group 45.67))");
+});

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1,0 +1,34 @@
+import { Token } from "./token.js";
+
+export interface Binary {
+	kind: "binary";
+	left: Expr;
+	operator: Token;
+	right: Expr;
+}
+
+export interface Grouping {
+	expr: Expr;
+	kind: "grouping";
+}
+
+export interface Literal {
+	kind: "literal";
+	value: null | number | string;
+}
+
+export interface Unary {
+	kind: "unary";
+	operator: Token;
+	right: Expr;
+}
+
+export type Expr = Binary | Grouping | Literal | Unary;
+
+export type ExpressionVisitor<R> = {
+	[Kind in Expr["kind"]]: (expr: Extract<Expr, { kind: Kind }>) => R;
+};
+
+export function visitExpr<R>(expr: Expr, visitor: ExpressionVisitor<R>): R {
+	return visitor[expr.kind](expr as never);
+}

--- a/src/token.ts
+++ b/src/token.ts
@@ -3,6 +3,7 @@ import { TokenType } from "./token-type.js";
 export interface Token {
 	lexeme: string;
 	line: number;
+	// XXX: not all TokenTypes should have "literal"
 	literal: null | number | string;
 	type: TokenType;
 }


### PR DESCRIPTION
## Overview

Implements AST from Chapter 5 of _Crafting Interpreters_.

This chapter is almost entirely Java-isms, so the TS version looks quite different. I'm actually very happy with it! Interfaces, tagged unions and mapped types are quite nice for reducing boilerplate here.