### PR TITLE
feat: add support for currency

### DIFF
--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -45,6 +45,12 @@ describe("parse", () => {
 		);
 	});
 
+	it("should parse expressions with currency", () => {
+		expect(parseToLisp("$1,123.45 + 2 * $37.48")).toMatchInlineSnapshot(
+			`"(+ 1123.45 (* 2 37.48))"`,
+		);
+	});
+
 	it("should error on unbalanced parens", () => {
 		const error = vi
 			.spyOn(console, "error")

--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -146,4 +146,22 @@ describe("Scanner", () => {
 			]
 		`);
 	});
+
+	it("should scan a number with commas", () => {
+		expect(scan(`123,456.789`)).toMatchInlineSnapshot(`
+			[
+			  "'123,456.789': number: 123456.789",
+			  "'': eof",
+			]
+		`);
+	});
+
+	it("should scan a number with commas starting with a dollar sign", () => {
+		expect(scan(`$123,456.79`)).toMatchInlineSnapshot(`
+			[
+			  "'$123,456.79': number: 123456.79",
+			  "'': eof",
+			]
+		`);
+	});
 });

--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -159,7 +159,7 @@ describe("Scanner", () => {
 	it("should scan a number with commas starting with a dollar sign", () => {
 		expect(scan(`$123,456.79`)).toMatchInlineSnapshot(`
 			[
-			  "'$123,456.79': number: 123456.79",
+			  "'$123,456.79': number: $123456.79",
 			  "'': eof",
 			]
 		`);

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -68,7 +68,10 @@ export class Scanner {
 	}
 
 	#number() {
-		while (isDigit(this.#peek())) {
+		if (this.#peek() === "$") {
+			this.#advance();
+		}
+		while (isDigit(this.#peek()) || this.#peek() === ",") {
 			this.#advance();
 		}
 		if (this.#peek() === "." && isDigit(this.#peekNext())) {
@@ -78,10 +81,10 @@ export class Scanner {
 			}
 		}
 
-		this.#addToken(
-			"number",
-			Number(this.source.slice(this.start, this.current)),
-		);
+		const numText = this.source
+			.slice(this.start, this.current)
+			.replace(/[$,]/g, "");
+		this.#addToken("number", Number(numText));
 	}
 
 	#peek() {
@@ -145,7 +148,7 @@ export class Scanner {
 				break;
 
 			default:
-				if (isDigit(c)) {
+				if (isDigit(c) || c === "$") {
 					this.#number();
 				} else if (isAlpha(c)) {
 					this.#identifier();

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -32,9 +32,15 @@ export class Scanner {
 		this.#addToken(c, null);
 	}
 
-	#addToken(type: TokenType, literal: Token["literal"]) {
-		const text = this.source.slice(this.start, this.current);
-		this.tokens.push({ lexeme: text, line: this.line, literal, type });
+	#addToken(type: TokenType, literal: Token["literal"], isCurrency?: boolean) {
+		const lexeme = this.source.slice(this.start, this.current);
+		this.tokens.push({
+			lexeme,
+			line: this.line,
+			literal,
+			type,
+			...(isCurrency && { isCurrency }),
+		});
 	}
 
 	#advance(): string {
@@ -68,9 +74,7 @@ export class Scanner {
 	}
 
 	#number() {
-		if (this.#peek() === "$") {
-			this.#advance();
-		}
+		const isCurrency = this.source[this.start] === "$";
 		while (isDigit(this.#peek()) || this.#peek() === ",") {
 			this.#advance();
 		}
@@ -84,7 +88,7 @@ export class Scanner {
 		const numText = this.source
 			.slice(this.start, this.current)
 			.replace(/[$,]/g, "");
-		this.#addToken("number", Number(numText));
+		this.#addToken("number", Number(numText), isCurrency);
 	}
 
 	#peek() {

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,6 +1,7 @@
 import { TokenType } from "./token-type.js";
 
 export interface Token {
+	isCurrency?: boolean;
 	lexeme: string;
 	line: number;
 	// XXX: not all TokenTypes should have "literal"
@@ -11,6 +12,8 @@ export interface Token {
 export function tokenToString(token: Token): string {
 	return (
 		`'${token.lexeme}': ${token.type}` +
-		(token.literal !== null ? `: ${token.literal}` : "")
+		(token.literal !== null
+			? `: ${token.isCurrency ? "$" : ""}${token.literal}`
+			: "")
 	);
 }


### PR DESCRIPTION
This is off track from the book, but I thought it would be a fun extension to support expressions like `$12.34 + $13.78`.

Any mix of units is allowed for now, though I might want to tweak this in the future. For example `2 * $12.34` makes sense but `2 + $12.34` probably doesn't.