### PR TITLE
feat: Add expression evaluation back to REPL

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -55,7 +55,7 @@ let throwMode = false;
 
 class ParseError extends Error {}
 
-function maybeParseAsExpression(line: string): Expr | null {
+export function maybeParseAsExpression(line: string): Expr | null {
 	throwMode = true;
 	try {
 		const scanner = new Scanner(line + ";");

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,9 +25,14 @@ export function resetErrors() {
 	hadRuntimeError = false;
 }
 
-export async function runPrompt(interpreter: Interpreter) {
-	process.stdout.write("> ");
-	for await (const line of createInterface({ input: process.stdin })) {
+export function runPrompt(interpreter: Interpreter) {
+	const rl = createInterface({
+		input: process.stdin,
+		output: process.stdout,
+		prompt: "> ",
+	});
+	rl.prompt();
+	rl.on("line", (line) => {
 		const expr = maybeParseAsExpression(line);
 		if (expr) {
 			console.log(stringify(interpreter.evaluate(expr)));
@@ -35,8 +40,8 @@ export async function runPrompt(interpreter: Interpreter) {
 			run(interpreter, line);
 		}
 		resetErrors();
-		process.stdout.write("> ");
-	}
+		rl.prompt();
+	});
 }
 
 let hadError = false;
@@ -111,6 +116,6 @@ export async function main() {
 	if (args.length == 1) {
 		await runFile(interpreter, args[0]);
 	} else {
-		await runPrompt(interpreter);
+		runPrompt(interpreter);
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import { once } from "node:events";
 import * as fs from "node:fs/promises";
 import { createInterface } from "node:readline";
 
@@ -25,7 +26,8 @@ export function resetErrors() {
 	hadRuntimeError = false;
 }
 
-export function runPrompt(interpreter: Interpreter) {
+export async function runPrompt(interpreter: Interpreter) {
+	// https://nodejs.org/api/readline.html#example-tiny-cli
 	const rl = createInterface({
 		input: process.stdin,
 		output: process.stdout,
@@ -42,6 +44,8 @@ export function runPrompt(interpreter: Interpreter) {
 		resetErrors();
 		rl.prompt();
 	});
+
+	await once(rl, "close");
 }
 
 let hadError = false;
@@ -116,6 +120,6 @@ export async function main() {
 	if (args.length == 1) {
 		await runFile(interpreter, args[0]);
 	} else {
-		runPrompt(interpreter);
+		await runPrompt(interpreter);
 	}
 }


### PR DESCRIPTION
This is chapter 8 challenge 1. This is a case where using a class for the parser would be helpful, since it would be easier to make both the `parse` and `expression` methods public.

I'm following the Node readline tiny CLI example: https://nodejs.org/api/readline.html#example-tiny-cli

It's nice to have up arrow in the CLI, but there's definitely a flicker that I don't love.