### PR TITLE
chore: Fancy coverage reports

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -5,7 +5,7 @@ jobs:
       - uses: mtfoley/pr-compliance-action@main
         with:
           body-auto-close: false
-          body-regex: PLEASE_NEVER_MATCH_I_DONT_USE_ISSUES
+          # body-regex: PLEASE_NEVER_MATCH_I_DONT_USE_ISSUES
           ignore-authors: |-
             allcontributors
             allcontributors[bot]

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 	],
 	"scripts": {
 		"build": "tsup",
+		"coverage": "pnpm test -- --coverage --no-watch",
 		"format": "prettier \"**/*\" --ignore-unknown",
 		"lint": "eslint . .*js --max-warnings 0",
 		"lint:knip": "knip",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,9 +5,15 @@ export default defineConfig({
 		clearMocks: true,
 		coverage: {
 			all: true,
-			exclude: ["lib"],
+			exclude: ["lib", "src/scripts"],
 			include: ["src"],
-			reporter: ["html", "lcov"],
+			reporter: [
+				[
+					"html-spa",
+					{ metricsToShow: ["branches", "functions", "lines", "statements"] },
+				],
+				"lcov",
+			],
 		},
 		exclude: ["lib", "node_modules"],
 		setupFiles: ["console-fail-test/setup"],


### PR DESCRIPTION
## Overview

Fixes #24 

This was a real trip down memory lane. There _has_ been a release of istanbul-reports since 2021 and vitest seems to use it https://github.com/istanbuljs/istanbuljs/pull/597

    pnpm coverage
    open coverage/index.html

Shows code coverage sorted by missing statements, just how I like it:

<img width="675" alt="image showing coverage reports sorted by missing lines" src="https://github.com/danvk/gravlax/assets/98301/8d6f88ba-c68e-4ab5-af3b-4d6fa18bd37e">
