### PR TITLE
chore: Refactor to make Interpreter not be a visitor

### DIFF
--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -8,19 +8,6 @@ import { CurrencyValue, LoxValue, isCurrency } from "./lox-value.js";
 import { runtimeError } from "./main.js";
 import { Token } from "./token.js";
 
-// TODO: Crafting Interpreters makes this anonymous, can I do that?
-class ClockFn extends LoxCallable {
-	arity() {
-		return 0;
-	}
-	call() {
-		return Date.now();
-	}
-	toString() {
-		return "<native fn>";
-	}
-}
-
 export class ReturnCall extends Error {
 	value: LoxValue;
 	constructor(value: LoxValue) {
@@ -77,7 +64,15 @@ export class Interpreter {
 	#locals = new Map<Expr, number>();
 
 	constructor() {
-		this.globals.define("clock", new ClockFn());
+		this.globals.define(
+			"clock",
+			// Can't use an object literal here because it must be instanceof LoxCallable.
+			new (class extends LoxCallable {
+				arity = () => 0;
+				call = () => Date.now();
+				toString = () => "<native fn>";
+			})(),
+		);
 	}
 
 	resolve(expr: Expr, depth: number) {


### PR DESCRIPTION
After [puzzling over](https://stackoverflow.com/questions/77876338/could-typescript-model-this-function-if-it-had-dependent-types) the visitor pattern in TypeScript, @mulias pointed out that I didn't really need it; pattern matching (via a switch statement) is the more idiomatic way to do this with a tagged union.

This is that refactor. There's a lot fewer imports, at least. No visitor but we still get exhaustiveness checking. For the `evaluate` method it's via the implicit return. For the `execute` method on expressions, we have to bake it in more explicitly.