### PR TITLE
fix: remove shebang line from `index.ts`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 	},
 	"type": "module",
 	"main": "./lib/index.js",
+	"bin": "./lib/index.js",
 	"files": [
 		"lib/",
 		"package.json",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,3 @@
-#!/usr/bin/env node --loader ts-node/esm --no-warnings
-
-// eslint-disable-next-line n/shebang
 import { main } from "./main.js";
 
 await main();


### PR DESCRIPTION
## Overview

It's OK for `index.ts`, but not for `index.js`. `"bin"` in `package.json` is set to `lib/index.js`, and `ts-node` is not installed with the npm package since it's a `devDependency`.

Fixes #41 