### PR TITLE
fix: make a separate index.js with a shebang to run as global binary

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/prepare
+      - run: pnpm build
       - run: pnpm lint
 
 name: Lint

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "./lib/index.js";

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
 	},
 	"type": "module",
 	"main": "./lib/index.js",
-	"bin": "./lib/index.js",
+	"bin": "./index.js",
 	"files": [
+		"index.js",
 		"lib/",
 		"package.json",
 		"LICENSE.md",


### PR DESCRIPTION
Fixes #50 

I don't love having to build before running lint. Other options would be to keep `src/index.ts` the executable and try to figure out how to make n/shebang understand that. Or to exclude the top-level `index.js` from linting.