### PR TITLE
fix: clock returns seconds, not milliseconds

### DIFF
--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -68,7 +68,7 @@ export class Interpreter {
 			// Can't use an object literal here because it must be instanceof LoxCallable.
 			new (class extends LoxCallable {
 				arity = () => 0;
-				call = () => Date.now();
+				call = () => Date.now() / 1000;
 				toString = () => "<native fn>";
 			})(),
 		);


### PR DESCRIPTION
## Overview

Fixes #51 

ref: https://craftinginterpreters.com/functions.html#telling-time